### PR TITLE
[FTE-405] extend documenation for project assignments call changes

### DIFF
--- a/fortytools.yaml
+++ b/fortytools.yaml
@@ -1782,6 +1782,51 @@ paths:
         422:
           description: Offer could not be printed
           content: {}
+  /project_assignments:
+    get:
+      tags:
+      - ProjectAssignment
+      description: |
+        List ProjectAssignments in a given period
+      parameters:
+      - name: staff_member_id
+        in: query
+        description: ID of the staff_member. Required if from and to are given.
+        required: false
+        schema:
+          type: integer
+      - name: from
+        in: query
+        description: first date of period. Not allowed if date if given.
+        required: true
+        schema:
+          type: string
+          format: date
+      - name: to
+        in: query
+        description: last date of period. Not allowed if date is given.
+        required: true
+        schema:
+          type: string
+          format: date
+      - name: date
+        in: query
+        description: date of period. Not allowed if from and to are given.
+        required: true
+        schema:
+          type: string
+          format: string
+      responses:
+        200:
+          description: Sends the project_assignments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProjectAssignment'
+        400:
+          description: Bad request - probably from and/or to params are missing
   /purchases:
     get:
       tags:
@@ -2319,18 +2364,25 @@ paths:
           type: integer
       - name: from
         in: query
-        description: first date of period
+        description: first date of period. Not allowed if date if given.
         required: true
         schema:
           type: string
           format: date
       - name: to
         in: query
-        description: last date of period
+        description: last date of period. Not allowed if date is given.
         required: true
         schema:
           type: string
           format: date
+      - name: date
+        in: query
+        description: date of period. Not allowed if from and to are given.
+        required: true
+        schema:
+          type: string
+          format: string
       responses:
         200:
           description: Sends the project_assignments

--- a/fortytools.yaml
+++ b/fortytools.yaml
@@ -1793,28 +1793,24 @@ paths:
       parameters:
       - name: staff_member_id
         in: query
-        description: ID of the staff_member. Required if from and to are given.
-        required: false
+        description: ID of the staff_member. Required if `from` and `to` are provided.
         schema:
           type: integer
       - name: from
         in: query
-        description: first date of period. Not allowed if date if given.
-        required: true
+        description: first date of period. Required if `date` is not provided; must not be set if `date` is given.
         schema:
           type: string
           format: date
       - name: to
         in: query
-        description: last date of period. Not allowed if date is given.
-        required: true
+        description: last date of period.  Required if `date` is not provided; must not be set if `date` is given.
         schema:
           type: string
           format: date
       - name: date
         in: query
-        description: date of period. Not allowed if from and to are given.
-        required: true
+        description: date of period. Must not be set if `from` and `to` are provided.
         schema:
           type: string
           format: string
@@ -2367,22 +2363,19 @@ paths:
           type: integer
       - name: from
         in: query
-        description: first date of period. Not allowed if date if given.
-        required: true
+        description: first date of period. Required if `date` is not provided; must not be set if `date` is given.
         schema:
           type: string
           format: date
       - name: to
         in: query
-        description: last date of period. Not allowed if date is given.
-        required: true
+        description: last date of period. Required if `date` is not provided; must not be set if `date` is given.
         schema:
           type: string
           format: date
       - name: date
         in: query
-        description: date of period. Not allowed if from and to are given.
-        required: true
+        description: date of period. Must not be set if `from` and `to` are provided.
         schema:
           type: string
           format: string

--- a/fortytools.yaml
+++ b/fortytools.yaml
@@ -1787,7 +1787,9 @@ paths:
       tags:
       - ProjectAssignment
       description: |
-        List ProjectAssignments in a given period
+        List ProjectAssignments in a given period.
+        Note: The `date` parameter may only be used if neither `from` nor `to` is provided. If either `from` or `to` is present, the `date` parameter must be omitted.
+        Additionally, if the `date` parameter is not used, the `staff_member_id` parameter is required. If `date` is provided, `staff_member_id` is optional.
       parameters:
       - name: staff_member_id
         in: query
@@ -2354,7 +2356,8 @@ paths:
       tags:
       - ProjectAssignment
       description: |
-        List ProjectAssignments for a StaffMember in a given period
+        List ProjectAssignments for a StaffMember in a given period.
+        Note: The `date` parameter may only be used if neither `from` nor `to` is provided. If either `from` or `to` is present, the `date` parameter must be omitted.
       parameters:
       - name: staff_member_id
         in: path


### PR DESCRIPTION
### Issue
[FTE-405](https://zvoove.atlassian.net/browse/FTE-405)

### Description
This adapts the documentation to reflect the changes from https://github.com/fortytools/skippr/pull/7672

Unfortunately, the OpenAPI currently does not allow the modelling of dependent query parameters (parameters that are required or not allowed depending on the presence or absence of other parameters). So tried to express this via the description of the calls.

The fields `sales_regime_id` and `wage_regime_id` were already documented.

### Open Questions
~Should we mark all query parameters as optional, as they are technically not actual required?~
They are marked as optional and an additional description is added.

[FTE-405]: https://zvoove.atlassian.net/browse/FTE-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ