### PR TITLE
FTE-660: add download_url fields to API documentation

### DIFF
--- a/fortytools.yaml
+++ b/fortytools.yaml
@@ -2897,7 +2897,7 @@ components:
           type: string
         download_url:
           type: string
-          description: a direct link to the attached contet valid for 10 minutes
+          description: a direct link to the attached file valid for 10 minutes
     AttachmentType:
       type: object
       properties:

--- a/fortytools.yaml
+++ b/fortytools.yaml
@@ -2895,6 +2895,9 @@ components:
           type: integer
         upload:
           type: string
+        download_url:
+          type: string
+          description: a direct link to the attached contet valid for 10 minutes
     AttachmentType:
       type: object
       properties:
@@ -3139,6 +3142,9 @@ components:
         notepaper_id:
           type: integer
           description: references the notepaper (pdf background)
+        download_url:
+          type: string
+          description: a direct link to the invoice valid for 10 minutes
     InvoiceLineItem:
       type: object
       properties:


### PR DESCRIPTION
## Jira Issue
[FTE-660](https://zvoove.atlassian.net/browse/FTE-660)


* See implementation PR here: https://github.com/fortytools/skippr/pull/8987

[FTE-660]: https://zvoove.atlassian.net/browse/FTE-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ